### PR TITLE
require pooch < 1.7 for 0.10.0, build bump

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -33,7 +33,7 @@ requirements:
     - decorator >=4.3.0
     - numba >=0.51.0
     - pysoundfile >=0.12.1
-    - pooch >=1.0
+    - pooch >=1.0, <1.7
     - packaging >=20.0
     - soxr-python >=0.3.2
     - lazy_loader >=0.1


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR adds an upper bound to the pooch dependency to avoid an incompatibility between librosa and pooch >=1.7.0.  It is equivalent to the `0.10.0.post2` package on pypi.